### PR TITLE
Update Fly deployment instructions and server config

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,4 +85,19 @@ python dashboard.py
 
 The generated CSV and HTML files can be shared with the rest of the team for review. Feel free to customise the scripts to add stores, adjust the demand model or extend the dashboard.
 
+## Running on Fly.io
+
+If you deploy this project on [Fly.io](https://fly.io) you may encounter errors
+when `mise` tries to download a prebuilt Python archive. Configure `mise` to
+compile Python from source instead:
+
+```bash
+mise settings set python_compile 1
+mise use -g python@3.12
+```
+
+The Flask app in `webapp.py` reads the `PORT` environment variable and listens
+on `0.0.0.0`, so Fly's router can reach it. Ensure your Fly configuration sets
+`PORT` accordingly (the default is `8080`).
+
 

--- a/webapp.py
+++ b/webapp.py
@@ -351,4 +351,5 @@ def scraping_sites_page():
 if __name__ == '__main__':
     with app.app_context():
         db.create_all()
-    app.run(debug=True)
+    port = int(os.environ.get('PORT', '8080'))
+    app.run(host='0.0.0.0', port=port, debug=True)


### PR DESCRIPTION
## Summary
- add a section in README with Fly.io instructions
- update `webapp.py` to listen on `0.0.0.0` and port from `PORT` environment variable

## Testing
- `python -m py_compile webapp.py`
- `python -m py_compile dashboard.py price_optimizer.py manage_products.py scraper.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_686d2db4d2b483208d977f6f7e26a66e