### PR TITLE
Add minimal Flask app

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,50 @@
+from flask import Flask, render_template, request, jsonify, send_file
+import subprocess
+import os
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/manage-products', methods=['GET', 'POST'])
+def manage_products():
+    if request.method == 'POST':
+        try:
+            result = subprocess.run(['python', 'manage_products.py'],
+                                    capture_output=True, text=True)
+            return jsonify({'status': 'success', 'output': result.stdout})
+        except Exception as e:
+            return jsonify({'status': 'error', 'message': str(e)})
+    return render_template('manage_products.html')
+
+@app.route('/scrape', methods=['POST'])
+def scrape():
+    try:
+        result = subprocess.run(['python', 'scraper.py'],
+                                capture_output=True, text=True)
+        return jsonify({'status': 'success', 'output': result.stdout})
+    except Exception as e:
+        return jsonify({'status': 'error', 'message': str(e)})
+
+@app.route('/optimize', methods=['POST'])
+def optimize():
+    try:
+        result = subprocess.run(['python', 'price_optimizer.py'],
+                                capture_output=True, text=True)
+        return jsonify({'status': 'success', 'output': result.stdout})
+    except Exception as e:
+        return jsonify({'status': 'error', 'message': str(e)})
+
+@app.route('/dashboard')
+def dashboard():
+    try:
+        subprocess.run(['python', 'dashboard.py'])
+        return send_file('dashboard.html')
+    except Exception as e:
+        return jsonify({'status': 'error', 'message': str(e)})
+
+if __name__ == '__main__':
+    port = int(os.environ.get('PORT', 8080))
+    app.run(host='0.0.0.0', port=port)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="container py-5">
+    <h1>Dzukou Pricing Toolkit</h1>
+    <p>Use the actions below to run the pricing workflow.</p>
+    <form action="/manage-products" method="post" class="mb-2">
+        <button class="btn btn-primary">Manage Products</button>
+    </form>
+    <form action="/scrape" method="post" class="mb-2">
+        <button class="btn btn-secondary">Run Scraper</button>
+    </form>
+    <form action="/optimize" method="post" class="mb-2">
+        <button class="btn btn-success">Optimize Prices</button>
+    </form>
+    <a href="/dashboard" class="btn btn-info">View Dashboard</a>
+</div>
+{% endblock %}

--- a/templates/manage_products.html
+++ b/templates/manage_products.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="container py-5">
+    <h1>Manage Products</h1>
+    <form method="post">
+        <button class="btn btn-primary">Launch Manager</button>
+    </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a simple Flask `app.py` using subprocess to run existing scripts
- provide small HTML pages for the index and manage-products page

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_686e53165abc832093c67fb79cee531e