### PR TITLE
Add fallback when Google credentials missing

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -7,6 +7,7 @@ import numpy as np
 from google_sheets_manager import get_manager
 
 BASE_DIR = Path(__file__).resolve().parent
+FALLBACK_OVERVIEW = BASE_DIR / "Dzukou_Pricing_Overview_With_Names - Copy.csv"
 SPREADSHEET_ID = "19urMb1e7hPHSs6rF5W6kckToXbBoaA-kauGSQsefw4Q"
 OVERVIEW_SHEET = "Sheet1"
 RECOMMENDED_CSV = BASE_DIR / "recommended_prices.csv"
@@ -14,9 +15,19 @@ OUT_HTML = BASE_DIR / "dashboard.html"
 
 
 def load_data():
-    """Load overview and recommendation data and compute deltas."""
-    manager = get_manager(SPREADSHEET_ID)
-    overview = manager.get_sheet_as_df(OVERVIEW_SHEET)
+    """Load overview and recommendation data and compute deltas.
+
+    If Google Sheets credentials are missing the function falls back to the
+    local CSV export ``FALLBACK_OVERVIEW``.
+    """
+    try:
+        manager = get_manager(SPREADSHEET_ID)
+        overview = manager.get_sheet_as_df(OVERVIEW_SHEET)
+    except Exception as exc:
+        if FALLBACK_OVERVIEW.exists():
+            overview = pd.read_csv(FALLBACK_OVERVIEW, encoding="cp1252")
+        else:
+            raise RuntimeError("Google Sheets credentials not found and fallback CSV missing") from exc
     recommended = pd.read_csv(RECOMMENDED_CSV)
 
     # Trim whitespace from column names and key fields so merges work


### PR DESCRIPTION
## Summary
- fall back to a local CSV export if Google credentials are missing in dashboard and price optimizer
- add pandas import for optimizer

## Testing
- `python dashboard.py`
- `python price_optimizer.py`

------
https://chatgpt.com/codex/tasks/task_e_687671bbf66c8320967232e6565b1912